### PR TITLE
Fix spawner imports

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 
 	"zeam/app"
+	"zeam/core/spawn/agent_spawner"
+	"zeam/core/spawn/presence_spawner"
 	"zeam/ipfs"
-	"zeam/spawn/agent_spawner"
-	"zeam/spawm/presence_spawner"
 )
 
 var runtime *app.App


### PR DESCRIPTION
## Summary
- update main imports to use `core/spawn/*`

## Testing
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6841b5f288808327b2a0bb2173d24e75